### PR TITLE
feat(ci): Remove variable for bucket

### DIFF
--- a/terraform/base/README.md
+++ b/terraform/base/README.md
@@ -21,7 +21,6 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | (Required) AWS region where the cluster was created. | `string` | n/a | yes |
-| <a name="input_bucket_ci"></a> [bucket\_ci](#input\_bucket\_ci) | Name of the bucket that stores the Terraform state files. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/terraform/base/provider.tf
+++ b/terraform/base/provider.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket  = var.bucket_ci
+    bucket  = "<BUCKET_NAME>"
     key     = "terraform/base/tfstate.tf"
     region  = "<AWS_DEFAULT_REGION>"
     encrypt = true

--- a/terraform/base/variables.tf
+++ b/terraform/base/variables.tf
@@ -2,8 +2,3 @@ variable "aws_region" {
   type        = string
   description = "(Required) AWS region where the cluster was created."
 }
-
-variable "bucket_ci" {
-  type        = string
-  description = "Name of the bucket that stores the Terraform state files."
-}


### PR DESCRIPTION
Terraform doesn't allow the use of variables in the backend and provider settings.

For this reason it's necessary to treat the bucket name with the replace mechanism in the go code.